### PR TITLE
Allow Symfony 4.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require": {
     "php": ">=5.3.3",
-    "symfony/console": "^2.1|^3.0"
+    "symfony/console": "^2.1 || ^3.0 || ^4.0"
   },
   "require-dev": {
     "symfony/process": "~2.1",


### PR DESCRIPTION
This PR allows Symfony 4.0 on composer.json in preparation for the Symfony 4.0 release on Nov 30 2017: http://symfony.com/blog/helping-prepare-for-symfony-4-bundle-support

#SymfonyConHackday2017